### PR TITLE
Fix change in options.targets.datasource

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -30,7 +30,13 @@ export class CompareQueriesDatasource {
   // Called once per panel (graph)
   query(options) {
     var _this = this;
-    var sets = _.groupBy(options.targets, 'datasource');
+    var sets = _.groupBy(options.targets, function(ds) {
+      // Trying to maintain compatibility with grafana lower then 8.3.x
+      if (ds.datasource.uid === undefined) {
+        return ds.datasource;
+      }
+      return ds.datasource.uid;
+    });
     var querys = _.groupBy(options.targets, 'refId');
     var promises: any[] = [];
     _.forEach(sets, function(targets, dsName) {


### PR DESCRIPTION
Datasource in options.targets are no longer a string in grafana 8.3.x but a key value object.
This pull request try to fix this change will maintaining compatibility with lower version of grafana.
If options.targets.datasource.uid doesn't exist then we keep old behavior in lowdash groupby function, if it exists, then lowdash groupby datasource.uid.
I tested this fix with grafana 8.2.7 and 8.3.1.

Closes #24 